### PR TITLE
initial setup for cloudfoundry deployment. 

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: cf/run.sh

--- a/cf/README.md
+++ b/cf/README.md
@@ -1,0 +1,25 @@
+Cloud Foundry Deployment
+========================
+
+__Note:__ This example is for the commercial pivotal cloud foundry using the `searchly` service.
+
++ initially create the elasticsearch service (if it doesnt exist)
+
+```bash
+cf create-service searchly starter registry_es
+```
+
++ push your app to cloudfoundry
+
+__Note:__ Adjust the name if you need in the yaml file.
+
+```yaml
+applications:
+- name: CUSTOM_DOMAIN
+```
+
+```bash
+cf push -f cf/commercial_test_pcf.yml
+```
+
++ access your app at {app_name}.cfapps.io

--- a/cf/README.md
+++ b/cf/README.md
@@ -6,7 +6,7 @@ __Note:__ This example is for the commercial pivotal cloud foundry using the `se
 + initially create the elasticsearch service (if it doesnt exist)
 
 ```bash
-cf create-service searchly starter registry_es
+cf create-service searchly starter es-dev
 ```
 
 + push your app to cloudfoundry
@@ -19,7 +19,7 @@ applications:
 ```
 
 ```bash
-cf push -f cf/commercial_test_pcf.yml
+cf push -f cf/pcf_dev.yml
 ```
 
 + access your app at {app_name}.cfapps.io

--- a/cf/commercial_test_pcf.yml
+++ b/cf/commercial_test_pcf.yml
@@ -1,0 +1,16 @@
+buildpack: https://github.com/boundlessgeo/python-buildpack.git
+domain: cfapps.io
+instances: 1
+memory: 512M
+disk_quota: 512M
+
+applications:
+- name: test-registry
+  services:
+    - registry_es
+
+  env:
+    SECRET_KEY: 'aadc-t8j*i5a7^y9@d^$at#g0!j_h=h++5stj=nb7z8u#l_y#&'
+    REGISTRY_DEBUG: 'True'
+    REGISTRY_MAPPING_PRECISION: '500m'
+    REGISTRY_INDEX_NAME: 'test-registry'

--- a/cf/pcf_dev.yml
+++ b/cf/pcf_dev.yml
@@ -1,0 +1,16 @@
+buildpack: https://github.com/boundlessgeo/python-buildpack.git
+domain: cfapps.io
+instances: 1
+memory: 512M
+disk_quota: 512M
+
+applications:
+- name: registry-dev
+  services:
+    - es-dev
+
+  env:
+    SECRET_KEY: 'aadc-t8j*i5a7^y9@d^$at#g0!j_h=h++5stj=nb7z8u#l_y#&'
+    REGISTRY_DEBUG: 'True'
+    REGISTRY_MAPPING_PRECISION: '500m'
+    REGISTRY_INDEX_NAME: 'registry-dev'

--- a/cf/pcf_test.yml
+++ b/cf/pcf_test.yml
@@ -5,12 +5,12 @@ memory: 512M
 disk_quota: 512M
 
 applications:
-- name: test-registry
+- name: registry-test
   services:
-    - registry_es
+    - es-test
 
   env:
     SECRET_KEY: 'aadc-t8j*i5a7^y9@d^$at#g0!j_h=h++5stj=nb7z8u#l_y#&'
     REGISTRY_DEBUG: 'True'
     REGISTRY_MAPPING_PRECISION: '500m'
-    REGISTRY_INDEX_NAME: 'test-registry'
+    REGISTRY_INDEX_NAME: 'registry-test'

--- a/cf/run.sh
+++ b/cf/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+echo "------ Setting up database -----"
+python registry.py pycsw -c setup_db
+
+echo "------ Running server instance -----"
+python registry.py runserver 0.0.0.0:$PORT

--- a/registry.py
+++ b/registry.py
@@ -55,9 +55,10 @@ REGISTRY_MAPPING_PRECISION = os.getenv('REGISTRY_MAPPING_PRECISION', '500m')
 REGISTRY_SEARCH_URL = os.getenv('REGISTRY_SEARCH_URL', 'http://127.0.0.1:9200')
 
 # cloudfoundry additions
-vcap_config = json.loads(os.environ.get('VCAP_SERVICES', None))
-if 'searchly' in vcap_config:
-    REGISTRY_SEARCH_URL = vcap_config['searchly'][0]['credentials']['sslUri']
+if 'VCAP_SERVICES' in os.environ:
+    vcap_config = json.loads(os.environ.get('VCAP_SERVICES', None))
+    if 'searchly' in vcap_config:
+        REGISTRY_SEARCH_URL = vcap_config['searchly'][0]['credentials']['sslUri']
 
 TIMEZONE = tz.gettz('America/New_York')
 
@@ -261,7 +262,7 @@ def record_to_dict(record):
 
 
 def get_or_create_catalog(es, version, catalog):
-    #TODO: Find a better way to catch exception in different ES versions.
+    # TODO: Find a better way to catch exception in different ES versions.
     try:
         es.get(catalog)
     except ElasticException as e:

--- a/registry.py
+++ b/registry.py
@@ -55,10 +55,10 @@ REGISTRY_MAPPING_PRECISION = os.getenv('REGISTRY_MAPPING_PRECISION', '500m')
 REGISTRY_SEARCH_URL = os.getenv('REGISTRY_SEARCH_URL', 'http://127.0.0.1:9200')
 
 # cloudfoundry additions
-if 'VCAP_SERVICES' in os.environ:
-    vcap_config = json.loads(os.environ.get('VCAP_SERVICES', None))
-    if 'searchly' in vcap_config:
-        REGISTRY_SEARCH_URL = vcap_config['searchly'][0]['credentials']['sslUri']
+if 'VCAP_SERVICES' in os.environ: # noqa
+    vcap_config = json.loads(os.environ.get('VCAP_SERVICES', None)) # noqa
+    if 'searchly' in vcap_config: # noqa
+        REGISTRY_SEARCH_URL = vcap_config['searchly'][0]['credentials']['sslUri'] # noqa
 
 TIMEZONE = tz.gettz('America/New_York')
 

--- a/registry.py
+++ b/registry.py
@@ -54,6 +54,11 @@ REGISTRY_INDEX_NAME = os.getenv('REGISTRY_INDEX_NAME', 'registry')
 REGISTRY_MAPPING_PRECISION = os.getenv('REGISTRY_MAPPING_PRECISION', '500m')
 REGISTRY_SEARCH_URL = os.getenv('REGISTRY_SEARCH_URL', 'http://127.0.0.1:9200')
 
+# cloudfoundry additions
+vcap_config = json.loads(os.environ.get('VCAP_SERVICES', None))
+if 'searchly' in vcap_config:
+    REGISTRY_SEARCH_URL = vcap_config['searchly'][0]['credentials']['sslUri']
+
 TIMEZONE = tz.gettz('America/New_York')
 
 LOGGING = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+# both required for cloudfoundry
+--extra-index-url https://pypi.python.org/simple
 --extra-index-url https://testpypi.python.org/pypi
 
 # pycsw


### PR DESCRIPTION
created a cf directory to allow for multiple manifest (.yml) files. Initial entry is for commercial pivotal for test.

added extra index url for requirements.txt. During the compile step cf wasa not able to find any packages from pypi, only testpypi.

added the ability to parse VCP_SERVICES env variable for searchly.  Will need to also include user provided service and in the future if a elastic service will be added to geoint pcf, then that will need to be added also.

added REGISTRY_INDEX_NAME to manifest file with default of  test-registry.

added readme for cloudfoundry