### PR TITLE
Add wms legend support

### DIFF
--- a/registry.py
+++ b/registry.py
@@ -45,7 +45,7 @@ from mapproxy.wsgiapp import MapProxyApp
 
 from shapely.geometry import box
 
-from six.moves.urllib_parse import urlparse, unquote as url_unquote
+from six.moves.urllib_parse import urlparse, unquote as url_unquote, urlencode
 
 from rawes.elastic_exception import ElasticException
 
@@ -343,6 +343,18 @@ def record_to_dict(record):
             ]
         }
     }
+
+    if(record.format == 'OGC:WMS'):
+        legend_opts = {
+            'SERVICE' : 'WMS',
+            'VERSION' : '1.1.1',
+            'REQUEST' : 'GetLegendGraphic',
+            'FORMAT' : 'image/png',
+            'LAYER' : record.title_alternate
+        }
+
+        record_dict['legend_url'] = '/layer/%s/service?' % record.identifier + urlencode(legend_opts)
+
 
     record_dict = include_registry_tags(record_dict, record.xml)
 

--- a/registry.py
+++ b/registry.py
@@ -1208,6 +1208,9 @@ def get_mapproxy(layer, seed=False, ignore_warnings=True, renderd=False, config_
             'url': url,
             'transparent': True,
         },
+        'wms_opts' : {
+            'legendgraphic' : True
+        }
     }
 
     if layer.type == 'ESRI:ArcGIS:MapServer' or layer.type == 'ESRI:ArcGIS:ImageServer':


### PR DESCRIPTION
The intention of this PR is to provide Legend support for those WMS sources which provide the capabilitiy.  As a general rule, Warper-sourced layers appear to fail when making GetLegendRequests.  In order to avoid that problem, the code below will only publish a legend_url for layers which are from OGC:WMS format layers.

Notes on the changes:

1. Line 48 adds an import for urlencode, which is used to ensure that stored URLs are properly formatted.
2. Lines 347-358 add a "legend_url" entry for layers which are from OGC:WMS formatted sources.
3. wms_opts gets "legendgraphic" for WMS-style layer entries to tell MapProxy to allow proxying of GetLegendGraphic requests.

