### PR TITLE
Include layer references in search backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 
 cache: pip
 sudo: required
-dist: xenial
+dist: trusty
 
 python:
   - "2.7"

--- a/registry.py
+++ b/registry.py
@@ -331,6 +331,19 @@ def include_registry_tags(record_dict, xml_file,
     return record_dict
 
 
+def parse_references(ref_string):
+    # Transform references into a list from pycsw string.
+    ref_list = ref_string.split(",,")[1:]
+
+    # Separate elements into list of list.
+    ref_list = [[data for data in ref.split(',')] for ref in ref_list]
+
+    # Construct list of dictionaries.
+    ref_list = [{'scheme': ref[0], 'url': ref[1].replace('^', '')} for ref in ref_list]
+
+    return ref_list
+
+
 def record_to_dict(record):
     # Encodes record title if it is not empty.
     if record.title:
@@ -381,6 +394,9 @@ def record_to_dict(record):
         record_dict['legend_url'] = '/layer/%s/service?' % record.identifier + urlencode(legend_opts)
 
     record_dict = include_registry_tags(record_dict, record.xml)
+
+    if record.links:
+        record_dict['references'] = parse_references(record.links)
 
     return record_dict
 

--- a/test_registry.py
+++ b/test_registry.py
@@ -39,6 +39,8 @@ layers_list = [
         'i': 0,
         'source': 'None',
         'type': 'ESRI:ArcGIS:ImageServer',
+        'references_scheme': 'WWW:LINK',
+        'references_url': 'http://some_url.com/rest/services/some_service/some_layer',
         'modified': datetime(2000, 3, 1, 0, 0, 0, tzinfo=registry.TIMEZONE)
     },
     {
@@ -54,6 +56,8 @@ layers_list = [
         'source': 'http://maps.nypl.org/warper/maps/wms/8198?',
         'i': 1,
         'type': 'dataset',
+        'references_scheme': 'WWW:LINK',
+        'references_url': 'http://some_url2.com/rest/services/some_service/some_layer',
         'modified': datetime(2001, 3, 1, 0, 0, 0, tzinfo=registry.TIMEZONE)
     },
     {
@@ -68,7 +72,9 @@ layers_list = [
         'registry_tag': 'vehicula',
         'i': 2,
         'type': 'ESRI:ArcGIS:MapServer',
-        'source': 'None',        
+        'source': 'None',
+        'references_scheme': 'OGC:WMS',
+        'references_url': 'http://some_wms_service/wms/2',
         'modified': datetime(2002, 3, 1, 0, 0, 0, tzinfo=registry.TIMEZONE)
     },
     {
@@ -155,6 +161,12 @@ def get_xml_block(dictionary):
          dictionary['source'],
          dictionary['identifier'],
          dictionary['registry_tag'])
+
+    if 'references_scheme' in dictionary.keys():
+        references_string = (
+            '    <dct:references scheme="%s">%s</dct:references>') % (dictionary['references_scheme'],
+                                                                      dictionary['references_url'])
+        xml_block += references_string
 
     if 'lower_corner_1' in dictionary.keys():
         bbox_string = (


### PR DESCRIPTION
This pull request enables elasticsearch to index layers references.  Within a layer, references must be included using this xml structure.
```
<dct:references scheme="scheme_type"> Server_url </dct:references>
```
Once a layer is indexed using this structure, elasticsearch will return a new field called **references**, which is a list of dictionaries whose fields correspond to "scheme" and "url"

**Note.** Search by scheme and/or search by reference url has not been included in the api (yet). 