### PR TITLE
Enabled search by reference in registry

### DIFF
--- a/search_api.yaml
+++ b/search_api.yaml
@@ -56,6 +56,16 @@ paths:
           description: Constrains docs by keyword search query.
           type: string
         -
+          name: q.references.url
+          in: query
+          description: Constrains docs by reference url search query.
+          type: string
+        -
+          name: q.references.scheme
+          in: query
+          description: Constrains docs by reference scheme search query.
+          type: string
+        -
           name: q.user
           in: query
           description: Constrains docs by matching exactly a certain user

--- a/test_registry.py
+++ b/test_registry.py
@@ -430,12 +430,36 @@ def test_search_api(client):
     results = json.loads(response.content.decode('utf-8'))
     assert len(layers_list) - 1 == results['a.matchDocs']
 
-    # Saarch only in registry subfield.
+    # Search only in registry subfield.
+    params = default_params.copy()
     params['q_registry_text'] = 'vehicula'
     response = client.get(catalog_search_api, params)
     assert 200 == response.status_code
     results = json.loads(response.content.decode('utf-8'))
     assert 2 == results['a.matchDocs']
+
+    # Get documents using an specific reference url.
+    params = default_params.copy()
+    params['q_references_url'] = 'http://some_url.com/rest/services/some_service/some_layer'
+    response = client.get(catalog_search_api, params)
+    assert 200 == response.status_code
+    results = json.loads(response.content.decode('utf-8'))
+    assert 1 == results['a.matchDocs']
+
+    # Get documents using an specific schema url.
+    params = default_params.copy()
+    params['q_references_scheme'] = 'WWW:LINK'
+    response = client.get(catalog_search_api, params)
+    assert 200 == response.status_code
+    results = json.loads(response.content.decode('utf-8'))
+    assert 2 == results['a.matchDocs']
+
+    # Get documents with both scheme and url references.
+    params['q_references_url'] = 'http://some_url.com/rest/services/some_service/some_layer'
+    response = client.get(catalog_search_api, params)
+    assert 200 == response.status_code
+    results = json.loads(response.content.decode('utf-8'))
+    assert 1 == results['a.matchDocs']
 
     params = default_params.copy()
     params['a_categories_limit'] = 10


### PR DESCRIPTION
This pull requests enables registry search by references. It is possible to execute requests to get records by reference url, reference scheme, or both at the same time.

- Included ```q_references_url``` and ```q_references_scheme``` in search api.
- Included nested request to search only in references field in elasticsearch.
- included tests.