### PR TITLE
enable search on category

### DIFF
--- a/registry.py
+++ b/registry.py
@@ -468,7 +468,7 @@ def es_mapping(version):
                     "registry": {
                         "type": "nested",
                         "properties": {
-                            "category": {"type": "string", "index": "not_analyzed"}
+                            "category": {"type": "string"}
                         }
                     },
                     "references": {


### PR DESCRIPTION
Remove "index":"not_analyzed" mapping for category to enable full text search against category